### PR TITLE
Upgrade worker CUDA, Ubuntu, GHA versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base image
-FROM nvidia/cuda:11.7.1-cudnn8-runtime-ubuntu20.04
+FROM nvidia/cuda:12.9.1-cudnn-devel-ubuntu24.04
 
 # Use bash shell with pipefail option
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -12,7 +12,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV RUNNER_ALLOW_RUNASROOT=1
 
 # GitHub runner version argument
-ARG RUNNER_VERSION=2.305.0
+ARG RUNNER_VERSION=2.327.1
 
 # Update and upgrade the system packages (Worker Template)
 RUN apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,18 +15,17 @@ ENV RUNNER_ALLOW_RUNASROOT=1
 ARG RUNNER_VERSION=2.327.1
 
 # Update and upgrade the system packages (Worker Template)
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y --no-install-recommends \
-    curl libssl-dev libffi-dev openssh-server python3 python3-dev python3-pip && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y \
+    curl libssl-dev libffi-dev libicu-dev libunwind8 libcurl4 \
+    zlib1g libkrb5-3 liblttng-ust-dev libgssapi-krb5-2 \
+    openssh-server python3 python3-dev python3-pip sudo && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
 
 # Install Python dependencies (Worker Template)
 COPY builder/requirements.txt /requirements.txt
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install --upgrade pip && \
-    pip install --upgrade -r /requirements.txt --no-cache-dir && \
+    pip install --upgrade -r /requirements.txt --no-cache-dir --break-system-packages && \
     rm /requirements.txt
 
 # cd into the user directory, download and unzip the github actions runner

--- a/builder/requirements.txt
+++ b/builder/requirements.txt
@@ -1,6 +1,6 @@
 # Required Python packages get listed here, one per line.
 # Reccomended to lock the version number to avoid unexpected changes.
 
-runpod~=1.7.0
+runpod~=1.7.13
 
-requests==2.31.0
+requests==2.32.4


### PR DESCRIPTION
I have made some updates to the worker image with some newer packages:
- Upgrade Ubuntu 20.04/CUDA 11.7.1 base image -> Ubuntu 24.04/CUDA 12.9.1
- Fetch latest GitHub action release `2.327.1`
- Installed some additional packages that were found to be missing during runtime
- Updated Python requirements for `runpod` and `requests` to their latest releases